### PR TITLE
Widget script embed load local

### DIFF
--- a/content/exchangeart.js
+++ b/content/exchangeart.js
@@ -34,7 +34,7 @@ const appendIframeContainer = async () => {
 
     let widgetContainer = document.createElement('div')
     widgetContainer.setAttribute('id', 'darkblock-widget-embed')
-    widgetContainer.setAttribute('style', "padding: 5px; width:100%; background-color:white;")
+    widgetContainer.setAttribute('style', "padding: 5px; width:100%;")
 
     let widgetScript = document.createElement('script')
     widgetScript.setAttribute('type', 'module')

--- a/content/exchangeart.js
+++ b/content/exchangeart.js
@@ -8,18 +8,13 @@ const waitForElement = selector => {
     return new Promise(resolve => {
 
         const loop = () => {
-
             const element = document.querySelector(selector)
-
             if (element)
                 return resolve(element)
-
-            setTimeout(loop, 1000)
-
         }
 
-        loop()
-
+        setTimeout(loop, 1000)
+        // loop()
     })
 }
 
@@ -29,41 +24,26 @@ const getTokenID = () => {
 }
 
 const appendIframeContainer = async () => {
-
     const shouldContinue = validateURLPath()
 
     if (!shouldContinue)
         return
 
     const tokenID = getTokenID()
+    const detailsContainer = await waitForElement('nft-extra-options')
 
-    const offerContainer = await waitForElement("nft-actions")
-    const iframeContainer = `<div class="opensea-ext--data-container "width: ${ offerContainer.getBoundingClientRect().width }px">
-                                <iframe
-                                    style="border: none; height: 550px; width: 100%; padding: 5px;"
-                                    title="darkblock"
-                                    src="https://app.darkblock.io/platform/sol/embed/viewer/${ tokenID }"
-                                    allowfullscreen=“allowfullscreen” mozallowfullscreen=“mozallowfullscreen” msallowfullscreen=“msallowfullscreen” oallowfullscreen=“oallowfullscreen” webkitallowfullscreen=“webkitallowfullscreen”>
-                                </iframe>
-                            </div>`
+    let widgetContainer = document.createElement('div')
+    widgetContainer.setAttribute('id', 'darkblock-widget-embed')
+    widgetContainer.setAttribute('style', "padding: 5px; width:100%; background-color:white;")
 
+    let widgetScript = document.createElement('script')
+    widgetScript.setAttribute('type', 'module')
+    widgetScript.setAttribute('id', 'darkblockwidget-script')
+    widgetScript.setAttribute('data-config', `{'platform':'Solana', 'tokenId': '${tokenID}'}`)
+    widgetScript.setAttribute('src', chrome.runtime.getURL("darkblock-widget-latest.js") )
 
-    offerContainer.insertAdjacentHTML("afterend", iframeContainer)
-
-    /* Not sure what is the exact reason, but the page re-renders after it gets loaded - therefore our container gets removed. Have to track that and re-add */
-    const interval = setInterval(() => {
-
-        const iframeExists = document.querySelector(".opensea-ext--data-container")
-
-        if (iframeExists)
-            return
-
-        clearInterval(interval)
-
-        appendIframeContainer()
-
-    }, 1000)
-
+    detailsContainer.insertAdjacentElement('afterend', widgetContainer)
+    document.body.appendChild(widgetScript)
 }
 
 /* Opensea works with dynamic pages. We have to track the URL change and only if that happens - attempt to append the iframe. */
@@ -79,12 +59,18 @@ const trackURLChange = () => {
             return
 
         appendIframeContainer()
-        
+
         oldURL = currentURL
 
     }, 1000)
 
 }
 
-appendIframeContainer()
-trackURLChange()
+const isloaded = () => {
+    window.onload = () => {
+        appendIframeContainer()
+        trackURLChange()
+    }
+}
+
+isloaded()

--- a/content/magiceden.js
+++ b/content/magiceden.js
@@ -8,18 +8,13 @@ const waitForElement = selector => {
     return new Promise(resolve => {
 
         const loop = () => {
-
             const element = document.querySelector(selector)
-
             if (element)
                 return resolve(element)
-
-            setTimeout(loop, 1000)
-
         }
 
-        loop()
-
+        setTimeout(loop, 1000)
+        // loop()
     })
 }
 
@@ -40,17 +35,19 @@ const appendIframeContainer = async () => {
     await waitForElement(".content")
 
     const offerContainer = document.querySelectorAll(".content > div")[3]
-    const iframeContainer = `<div class="opensea-ext--data-container "width: ${ offerContainer.getBoundingClientRect().width }px">
-                                <iframe
-                                    style="border: none; height: 550px; width: 100%; padding: 5px;"
-                                    title="darkblock"
-                                    src="https://app.darkblock.io/platform/sol/embed/viewer/${ tokenID }"
-                                    allowfullscreen=“allowfullscreen” mozallowfullscreen=“mozallowfullscreen” msallowfullscreen=“msallowfullscreen” oallowfullscreen=“oallowfullscreen” webkitallowfullscreen=“webkitallowfullscreen”>
-                                </iframe>
-                            </div>`
 
-    offerContainer.insertAdjacentHTML("afterend", iframeContainer)
+    let widgetContainer = document.createElement('div')
+    widgetContainer.setAttribute('id', 'darkblock-widget-embed')
+    widgetContainer.setAttribute('style', "padding: 5px; width:100%; background-color:white;")
 
+    let widgetScript = document.createElement('script')
+    widgetScript.setAttribute('type', 'module')
+    widgetScript.setAttribute('id', 'darkblockwidget-script')
+    widgetScript.setAttribute('data-config', `{'platform':'Solana', 'tokenId': '${tokenID}'}`)
+    widgetScript.setAttribute('src', chrome.runtime.getURL("darkblock-widget-latest.js") )
+
+    offerContainer.insertAdjacentElement("afterend", widgetContainer)
+    document.body.appendChild(widgetScript)
 }
 
 /* Opensea works with dynamic pages. We have to track the URL change and only if that happens - attempt to append the iframe. */
@@ -66,12 +63,18 @@ const trackURLChange = () => {
             return
 
         appendIframeContainer()
-        
+
         oldURL = currentURL
 
     }, 1000)
 
 }
 
-appendIframeContainer()
-trackURLChange()
+const isloaded = () => {
+    window.onload = () => {
+        appendIframeContainer()
+        trackURLChange()
+    }
+}
+
+isloaded()

--- a/content/magiceden.js
+++ b/content/magiceden.js
@@ -38,7 +38,7 @@ const appendIframeContainer = async () => {
 
     let widgetContainer = document.createElement('div')
     widgetContainer.setAttribute('id', 'darkblock-widget-embed')
-    widgetContainer.setAttribute('style', "padding: 5px; width:100%; background-color:white;")
+    widgetContainer.setAttribute('style', "padding: 5px; width:100%;")
 
     let widgetScript = document.createElement('script')
     widgetScript.setAttribute('type', 'module')

--- a/content/solsea.js
+++ b/content/solsea.js
@@ -8,18 +8,13 @@ const waitForElement = selector => {
     return new Promise(resolve => {
 
         const loop = () => {
-
             const element = document.querySelector(selector)
-
             if (element)
                 return resolve(element)
-
-            setTimeout(loop, 1000)
-
         }
 
-        loop()
-
+        setTimeout(loop, 1000)
+        // loop()
     })
 }
 
@@ -37,19 +32,33 @@ const appendIframeContainer = async () => {
 
     const tokenID = getTokenID()
 
-    const importantMessageContainer = await waitForElement("[class^=important-message__InfoSection]")
-    const iframeContainer = `<div class="opensea-ext--data-container "width: ${ importantMessageContainer.getBoundingClientRect().width }px">
-                                <iframe
-                                    style="border: none; height: 550px; width: 100%; padding: 5px;"
-                                    title="darkblock"
-                                    src="https://app.darkblock.io/platform/sol/embed/viewer/${ tokenID }"
-                                    allowfullscreen=“allowfullscreen” mozallowfullscreen=“mozallowfullscreen” msallowfullscreen=“msallowfullscreen” oallowfullscreen=“oallowfullscreen” webkitallowfullscreen=“webkitallowfullscreen”>
-                                </iframe>
-                            </div>`
+    // const importantMessageContainer = await waitForElement("[class^=important-message__InfoSection]")
+    // const iframeContainer = `<div class="opensea-ext--data-container "width: ${ importantMessageContainer.getBoundingClientRect().width }px">
+    //                             <iframe
+    //                                 style="border: none; height: 550px; width: 100%; padding: 5px;"
+    //                                 title="darkblock"
+    //                                 src="https://app.darkblock.io/platform/sol/embed/viewer/${ tokenID }"
+    //                                 allowfullscreen=“allowfullscreen” mozallowfullscreen=“mozallowfullscreen” msallowfullscreen=“msallowfullscreen” oallowfullscreen=“oallowfullscreen” webkitallowfullscreen=“webkitallowfullscreen”>
+    //                             </iframe>
+    //                         </div>`
 
+    // importantMessageContainer.insertAdjacentHTML("afterend", iframeContainer)
 
-    importantMessageContainer.insertAdjacentHTML("afterend", iframeContainer)
+    const importantMessageContainer = await waitForElement("[class^=info-column__NFTPage_Pqio1]")
 
+    let widgetDiv = document.createElement('div')
+    widgetDiv.setAttribute('id', 'darkblock-widget-embed')
+    widgetDiv.setAttribute('style', "padding: 5px; width:100%; background-color:white;")
+
+    let widgetScript = document.createElement('script')
+    widgetScript.setAttribute('type', 'module')
+    widgetScript.setAttribute('id', 'darkblockwidget-script')
+    widgetScript.setAttribute('data-config', "{'platform':'Solana', 'tokenId': '28qnjJqxMeVJFRyNDp8yfGwd5DRsRYtoUnQncHWtyfRb'}")
+    widgetScript.setAttribute('src', 'https://main--reliable-brigadeiros-e04b05.netlify.app/darkblock-widget-latest.js')
+
+    // importantMessageContainer.insertAdjacentElement('afterend', widgetDiv)
+    importantMessageContainer.appendChild(widgetDiv)
+    document.body.appendChild(widgetScript)
 }
 
 /* Opensea works with dynamic pages. We have to track the URL change and only if that happens - attempt to append the iframe. */
@@ -65,7 +74,7 @@ const trackURLChange = () => {
             return
 
         appendIframeContainer()
-        
+
         oldURL = currentURL
 
     }, 1000)

--- a/content/solsea.js
+++ b/content/solsea.js
@@ -33,9 +33,9 @@ const appendIframeContainer = async () => {
     const tokenID = getTokenID()
     const importantMessageContainer = await waitForElement("[class^=important-message__InfoSection]")
 
-    let widgetDiv = document.createElement('div')
-    widgetDiv.setAttribute('id', 'darkblock-widget-embed')
-    widgetDiv.setAttribute('style', "padding: 5px; width:100%; background-color:white;")
+    let widgetContainer = document.createElement('div')
+    widgetContainer.setAttribute('id', 'darkblock-widget-embed')
+    widgetContainer.setAttribute('style', "padding: 5px; width:100%; background-color:white;")
 
     let widgetScript = document.createElement('script')
     widgetScript.setAttribute('type', 'module')
@@ -43,7 +43,7 @@ const appendIframeContainer = async () => {
     widgetScript.setAttribute('data-config', `{'platform':'Solana', 'tokenId': '${tokenID}'}`)
     widgetScript.setAttribute('src', chrome.runtime.getURL("darkblock-widget-latest.js") )
 
-    importantMessageContainer.insertAdjacentElement('afterend', widgetDiv)
+    importantMessageContainer.insertAdjacentElement('afterend', widgetContainer)
     document.body.appendChild(widgetScript)
 }
 

--- a/content/solsea.js
+++ b/content/solsea.js
@@ -35,7 +35,7 @@ const appendIframeContainer = async () => {
 
     let widgetContainer = document.createElement('div')
     widgetContainer.setAttribute('id', 'darkblock-widget-embed')
-    widgetContainer.setAttribute('style', "padding: 5px; width:100%; background-color:white;")
+    widgetContainer.setAttribute('style', "padding: 5px; width:100%;")
 
     let widgetScript = document.createElement('script')
     widgetScript.setAttribute('type', 'module')

--- a/content/solsea.js
+++ b/content/solsea.js
@@ -44,6 +44,9 @@ const appendIframeContainer = async () => {
 
     // importantMessageContainer.insertAdjacentHTML("afterend", iframeContainer)
 
+    console.log('is loaded? ', 'chrome-extension://__MSG_@@extension_id__/content/darkblock-widget-latest.js');
+    // console.log('is loaded? ', chrome.extension.getUrl('content/darkblock-widget-latest.js'));
+
     const importantMessageContainer = await waitForElement("[class^=info-column__NFTPage_Pqio1]")
 
     let widgetDiv = document.createElement('div')
@@ -54,7 +57,8 @@ const appendIframeContainer = async () => {
     widgetScript.setAttribute('type', 'module')
     widgetScript.setAttribute('id', 'darkblockwidget-script')
     widgetScript.setAttribute('data-config', "{'platform':'Solana', 'tokenId': '28qnjJqxMeVJFRyNDp8yfGwd5DRsRYtoUnQncHWtyfRb'}")
-    widgetScript.setAttribute('src', 'https://main--reliable-brigadeiros-e04b05.netlify.app/darkblock-widget-latest.js')
+    // widgetScript.setAttribute('src', 'https://main--reliable-brigadeiros-e04b05.netlify.app/darkblock-widget-latest.js')
+    widgetScript.setAttribute('src', chrome.extension.getUrl('content/darkblock-widget-latest.js'))
 
     // importantMessageContainer.insertAdjacentElement('afterend', widgetDiv)
     importantMessageContainer.appendChild(widgetDiv)

--- a/content/solsea.js
+++ b/content/solsea.js
@@ -31,23 +31,7 @@ const appendIframeContainer = async () => {
         return
 
     const tokenID = getTokenID()
-
-    // const importantMessageContainer = await waitForElement("[class^=important-message__InfoSection]")
-    // const iframeContainer = `<div class="opensea-ext--data-container "width: ${ importantMessageContainer.getBoundingClientRect().width }px">
-    //                             <iframe
-    //                                 style="border: none; height: 550px; width: 100%; padding: 5px;"
-    //                                 title="darkblock"
-    //                                 src="https://app.darkblock.io/platform/sol/embed/viewer/${ tokenID }"
-    //                                 allowfullscreen=“allowfullscreen” mozallowfullscreen=“mozallowfullscreen” msallowfullscreen=“msallowfullscreen” oallowfullscreen=“oallowfullscreen” webkitallowfullscreen=“webkitallowfullscreen”>
-    //                             </iframe>
-    //                         </div>`
-
-    // importantMessageContainer.insertAdjacentHTML("afterend", iframeContainer)
-
-    console.log('is loaded? ', 'chrome-extension://__MSG_@@extension_id__/content/darkblock-widget-latest.js');
-    // console.log('is loaded? ', chrome.extension.getUrl('content/darkblock-widget-latest.js'));
-
-    const importantMessageContainer = await waitForElement("[class^=info-column__NFTPage_Pqio1]")
+    const importantMessageContainer = await waitForElement("[class^=important-message__InfoSection]")
 
     let widgetDiv = document.createElement('div')
     widgetDiv.setAttribute('id', 'darkblock-widget-embed')
@@ -56,12 +40,10 @@ const appendIframeContainer = async () => {
     let widgetScript = document.createElement('script')
     widgetScript.setAttribute('type', 'module')
     widgetScript.setAttribute('id', 'darkblockwidget-script')
-    widgetScript.setAttribute('data-config', "{'platform':'Solana', 'tokenId': '28qnjJqxMeVJFRyNDp8yfGwd5DRsRYtoUnQncHWtyfRb'}")
-    // widgetScript.setAttribute('src', 'https://main--reliable-brigadeiros-e04b05.netlify.app/darkblock-widget-latest.js')
-    widgetScript.setAttribute('src', chrome.extension.getUrl('content/darkblock-widget-latest.js'))
+    widgetScript.setAttribute('data-config', `{'platform':'Solana', 'tokenId': '${tokenID}'}`)
+    widgetScript.setAttribute('src', chrome.runtime.getURL("darkblock-widget-latest.js") )
 
-    // importantMessageContainer.insertAdjacentElement('afterend', widgetDiv)
-    importantMessageContainer.appendChild(widgetDiv)
+    importantMessageContainer.insertAdjacentElement('afterend', widgetDiv)
     document.body.appendChild(widgetScript)
 }
 
@@ -85,5 +67,11 @@ const trackURLChange = () => {
 
 }
 
-appendIframeContainer()
-trackURLChange()
+const isloaded = () => {
+    window.onload = () => {
+        appendIframeContainer()
+        trackURLChange()
+    }
+}
+
+isloaded()

--- a/manifest.json
+++ b/manifest.json
@@ -27,5 +27,11 @@
       "js": ["content/solsea.js"],
       "css": ["content.css"]
     }
-  ]
+  ],
+  "web_accessible_resources": [
+    {
+      "matches": ["https://solsea.io/*"],
+      "resources": ["content/darkblock-widget-latest.js"]
+    }
+ ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,7 @@
   ],
   "web_accessible_resources": [
     {
-      "matches": ["https://solsea.io/*"],
+      "matches": ["https://solsea.io/*", "https://magiceden.io/*"],
       "resources": ["darkblock-widget-latest.js"]
     }
  ]

--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,7 @@
   "web_accessible_resources": [
     {
       "matches": ["https://solsea.io/*"],
-      "resources": ["content/darkblock-widget-latest.js"]
+      "resources": ["darkblock-widget-latest.js"]
     }
  ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,11 @@
   ],
   "web_accessible_resources": [
     {
-      "matches": ["https://solsea.io/*", "https://magiceden.io/*"],
+      "matches": [
+        "https://solsea.io/*",
+        "https://magiceden.io/*",
+        "https://exchange.art/*"
+      ],
       "resources": ["darkblock-widget-latest.js"]
     }
  ]


### PR DESCRIPTION
# Add Widget Embed Script to display Solana Widget - The widget is loaded from the local resources of Chrome

* Add widget from local resources of Chome extension
* Start the loading of the widget when the page is fully loaded
* Support for: Exchange art, Magic Eden & Solsea

![image](https://user-images.githubusercontent.com/97113254/207721606-17b81040-3f90-44b6-8519-e4f6377fcc6f.png)

![image](https://user-images.githubusercontent.com/97113254/207721645-8f69b3bc-b378-4255-9ae6-5c7c0e4f809a.png)

![image](https://user-images.githubusercontent.com/97113254/207721711-e23bd195-6ff5-4519-b5d5-335a9611eeda.png)

